### PR TITLE
following now gets updated when following or unfollowing a user

### DIFF
--- a/frontend/src/routes/Login.js
+++ b/frontend/src/routes/Login.js
@@ -52,6 +52,7 @@ const Login = () => {
             accountData.rememberMe = rememberMe
             setStoredCredentials(accountData)
             if (rememberMe) localStorage.setItem('SebMediaCredentials', JSON.stringify(accountData))
+            localStorage.setItem('following', JSON.stringify(accountData.following))
             navigate('/home')
         }).catch(error => {
             setLoading(false)

--- a/frontend/src/routes/Profile.js
+++ b/frontend/src/routes/Profile.js
@@ -484,6 +484,7 @@ const Profile = () => {
                         setIsFollowing(true)
                         followingOrUnfollowing.current = false;
                         console.log(result?.data?.message)
+                        localStorage.setItem('following', JSON.stringify(parseInt(localStorage.getItem('following')) + 1)) //Add one follower to the following local storage item
                     }).catch(error => {
                         console.error(error)
                         alert(error?.response?.data?.error || String(error))
@@ -499,6 +500,7 @@ const Profile = () => {
                         setIsFollowing(false)
                         followingOrUnfollowing.current = false;
                         console.log(result?.data?.message)
+                        localStorage.setItem('following', JSON.stringify(parseInt(localStorage.getItem('following')) - 1)) //Remove one follower to the following local storage item
                     }).catch(error => {
                         console.error(error)
                         alert(error?.response?.data?.error || String(error))
@@ -549,7 +551,7 @@ const Profile = () => {
                             <H3NoMargin>{followerNumber === 1 ? 'Follower' : 'Followers'}</H3NoMargin>
                         </FlexColumnCentreDiv>
                         <FlexColumnCentreDiv style={{cursor: 'pointer'}} onClick={() => profilePublicId && profilePublicId !== publicId ? navigate(`/following/${profilePublicId}/${profileData.name}`) : navigate('/following')}>
-                            <H3NoMargin>{profilePublicId ? profileData.following : following}</H3NoMargin>
+                            <H3NoMargin>{profilePublicId ? profileData.following : localStorage.getItem('following')}</H3NoMargin>
                             <H3NoMargin>Following</H3NoMargin>
                             {profilePublicId && profileData.isFollower && <H3NoMargin>({profileData.name} follows you)</H3NoMargin>}
                         </FlexColumnCentreDiv>

--- a/frontend/src/routes/Signup.js
+++ b/frontend/src/routes/Signup.js
@@ -48,6 +48,7 @@ const Signup = () => {
             setStoredCredentials(result)
             result.rememberMe = true;
             if (rememberMe) localStorage.setItem('SebMediaCredentials', JSON.stringify(result))
+            localStorage.setItem('following', '0')
             navigate('/home')
         }).catch(error => {
             setLoading(false)


### PR DESCRIPTION
Instead of using storedCredentials.following, SebMedia now uses localStorage so SebMedia doesn't have to re-render every time the user follows or unfollows a user