### PR TITLE
follower number now updates automatically when visiting profile screen

### DIFF
--- a/backend/controllers/User.js
+++ b/backend/controllers/User.js
@@ -1264,6 +1264,21 @@ const editImagePost = async (req, res) => {
     })
 }
 
+const refreshUserFollowers = (req, res) => {
+    const userId = req?.body?.userId
+
+    const error = errorCheck.checkIfValueIsValidObjectId('userId', userId)
+    if (error) {
+        return http.BadInput(res, error)
+    }
+
+    user.getFollowersFromUserById(userId).then(followers => {
+        http.OK(res, 'Successfully retrieved followers', followers.length)
+    }).catch(error => {
+        http.ServerError(res, 'An error occured while retrieving followers. Please try again later.')
+    })
+}
+
 module.exports = {
     login,
     signup,
@@ -1285,5 +1300,6 @@ module.exports = {
     getUserFollowers,
     getUserFollowing,
     editTextPost,
-    editImagePost
+    editImagePost,
+    refreshUserFollowers
 }

--- a/backend/libraries/User.js
+++ b/backend/libraries/User.js
@@ -123,6 +123,17 @@ class UserLibrary {
             ]).then(resolve).catch(reject)
         })
     }
+
+    getFollowersFromUserById = (userId) => {
+        return new Promise(async (resolve, reject) => {
+            try {
+                const userFoundById = await this.findUserById(userId)
+                resolve(userFoundById.followers)
+            } catch (error) {
+                reject(error)
+            }
+        })
+    }
 }
 
 module.exports = UserLibrary

--- a/backend/routes/User.js
+++ b/backend/routes/User.js
@@ -21,7 +21,8 @@ const {
     getUserFollowers,
     getUserFollowing,
     editTextPost,
-    editImagePost
+    editImagePost,
+    refreshUserFollowers
 } = require('../controllers/User')
 const multer = require('multer')
 const path = require('path')
@@ -115,5 +116,7 @@ router.post('/getUserFollowing', getUserFollowing)
 router.put('/textpost', editTextPost)
 
 router.put('/imagepost', editImagePost)
+
+router.post('/refreshuserfollowers', refreshUserFollowers)
 
 module.exports = router;

--- a/frontend/src/routes/Login.js
+++ b/frontend/src/routes/Login.js
@@ -53,6 +53,7 @@ const Login = () => {
             setStoredCredentials(accountData)
             if (rememberMe) localStorage.setItem('SebMediaCredentials', JSON.stringify(accountData))
             localStorage.setItem('following', JSON.stringify(accountData.following))
+            localStorage.setItem('followers', JSON.stringify(accountData.followers))
             navigate('/home')
         }).catch(error => {
             setLoading(false)

--- a/frontend/src/routes/Profile.js
+++ b/frontend/src/routes/Profile.js
@@ -23,7 +23,7 @@ var _ = require('lodash')
 const Profile = () => {
     const {storedCredentials, setStoredCredentials} = useContext(CredentialsContext)
     const { FlexRowCentreDiv, FlexColumnCentreDiv, FlexRowSpaceAroundDiv, H3NoMargin } = useComponent()
-    const {name, followers, following, profileImageUri, _id, publicId} = storedCredentials;
+    const {name, profileImageUri, _id, publicId} = storedCredentials;
     const [view, setView] = useState('textPosts')
     const [openProfileImageFileSelector, { plainFiles: profileImageToUpload, loading: profileImageFileLoading}] = useFilePicker({accept: 'image/jpeg', multiple: false})
     const [profileImageUploading, setProfileImageUploading] = useState(false);
@@ -37,6 +37,7 @@ const Profile = () => {
     const followingOrUnfollowing = useRef(false)
     const [isFollowing, setIsFollowing] = useState(null)
     const navigate = useNavigate()
+    const followers = parseInt(localStorage.getItem('followers'))
 
     //Set to followers if you are visitng your own profile page via the profile button.
     //Set to followers if you are visitng your own profile page via the search page.
@@ -63,6 +64,24 @@ const Profile = () => {
                 followers
         )
     }, [profilePublicId, profileData, isFollowing])
+
+    useEffect(() => {
+        //When the profile page first loads, if the user is looking at their own profile page, refresh the follower count.
+        if (!profilePublicId || profilePublicId === publicId) {
+            const toSend = {
+                userId: _id
+            }
+            const url = `${serverUrl}/user/refreshuserfollowers`
+
+            axios.post(url, toSend).then(response => response.data.data).then(result => {
+                localStorage.setItem('followers', JSON.stringify(result))
+                if (result !== followerNumber) {
+                    console.log('Updating follower number')
+                    setFollowerNumber(result)
+                }
+            })
+        }
+    }, [profilePublicId, publicId])
 
     const loadPublicProfileInformation = () => {
         setLoadingProfile(true)

--- a/frontend/src/routes/Signup.js
+++ b/frontend/src/routes/Signup.js
@@ -49,6 +49,7 @@ const Signup = () => {
             result.rememberMe = true;
             if (rememberMe) localStorage.setItem('SebMediaCredentials', JSON.stringify(result))
             localStorage.setItem('following', '0')
+            localStorage.setItem('followers', '0')
             navigate('/home')
         }).catch(error => {
             setLoading(false)


### PR DESCRIPTION
Instead of using storedCredentials.followers to display the user's followers, the followers has now been put into local storage item 'followers' to prevent unneccesary rerenders when updating followers